### PR TITLE
Slider is partially cutoff.

### DIFF
--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -114,5 +114,5 @@ html {
 }
 
 #slider {
-  overflow-x: visible !important;
+  overflow-x: visible !important;  // Grommet hides overflow-x
 }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -112,3 +112,7 @@ html {
     }
   }
 }
+
+#slider {
+  overflow-x: visible !important;
+}


### PR DESCRIPTION
The following class is currently applied to the slider. It causes the slider to be cutoff on top and bottom slightly.

.grommet input[type=range] {
    overflow-x: hidden;
}

Tested on Chrome and Edge.

Before Change:
![before](https://user-images.githubusercontent.com/30356385/35201111-09fefa2c-fede-11e7-8b68-92932fed06c0.PNG)

After Change:
![after](https://user-images.githubusercontent.com/30356385/35201118-0d23f0c2-fede-11e7-9a25-905d9093dbbb.PNG)

